### PR TITLE
Fix: Handle --index option properly to avoid ValueError on invalid input

### DIFF
--- a/docstamp/cli/cli.py
+++ b/docstamp/cli/cli.py
@@ -50,7 +50,7 @@ def cli():
               default='inkscape', show_default=True,
               help='The rendering command to be used in case file name '
                    'extension is not specific.')
-@click.option('--index', default=[],
+@click.option('--index', type=int, multiple=True,
               help='Index/es of the CSV file that you want to create the '
                    'document from. Note that the samples numbers start from 0 '
                    'and the empty ones do not count.')
@@ -98,7 +98,7 @@ def create(input, template, field, outdir, prefix, otype, command, index,
 
     # filter the items if index
     if index:
-        myitems = {int(idx): items[int(idx)] for idx in index}
+        myitems = {idx: items[idx] for idx in index}
         items = myitems
         log.debug('Using the elements with index {} of the input '
                   'file.'.format(index))


### PR DESCRIPTION
This PR fixes a bug that occurred when the --index option was not provided by the user. In such cases, Click would pass a string representation of an empty list ("[]") instead of a proper empty tuple or list of integers.

This led to the following error during execution: `ValueError: invalid literal for int() with base 10: '['`